### PR TITLE
feat: Implement AuditLoggerService and integrate into pipeline

### DIFF
--- a/claims_processor/src/core/security/audit_logger_service.py
+++ b/claims_processor/src/core/security/audit_logger_service.py
@@ -1,100 +1,124 @@
-from sqlalchemy.ext.asyncio import AsyncSession
-from datetime import datetime, timezone # To ensure timezone awareness if not handled by DB default
-from typing import Optional, Dict, Any
 import structlog
+from typing import Optional, Dict, Any, Callable
+from sqlalchemy.ext.asyncio import AsyncSession
+from datetime import datetime # Not strictly needed if AuditLogModel uses server_default for timestamp
 
-# Assuming AuditLogModel is in:
+# Assuming AuditLogModel is correctly imported
 from ..database.models.audit_log_db import AuditLogModel
+# Assuming db_session.py provides a way to get a session, e.g., AsyncSessionLocal
+# from ..database.db_session import AsyncSessionLocal # Example, actual factory might differ
 
 logger = structlog.get_logger(__name__)
 
 class AuditLoggerService:
-    def __init__(self, db_session: AsyncSession):
-        self.db = db_session
+    """
+    Service for logging audit events to the database.
+    """
+
+    def __init__(self, db_session_factory: Callable[[], AsyncSession]): # Expects a factory that returns a session
+        """
+        Initializes the AuditLoggerService.
+
+        Args:
+            db_session_factory: An asynchronous factory function that provides an AsyncSession.
+                                e.g., the `get_db_session` context manager producer from `db_session.py`
+                                or `AsyncSessionLocal` directly if not using Depends-like context.
+                                For a service, a factory that can be called to create a session is typical.
+                                Let's assume it's a callable that yields an AsyncSession context manager.
+                                Or more simply, a callable that returns a session directly for internal use.
+                                The processor uses `async with self.db_session_factory() as session:`.
+                                So this service should probably do the same.
+        """
+        self.db_session_factory = db_session_factory
+        logger.info("AuditLoggerService initialized.")
 
     async def log_event(
         self,
         action: str,
         success: bool,
-        user_id: Optional[str] = None,
         resource: Optional[str] = None,
         resource_id: Optional[str] = None,
-        patient_id_hash: Optional[str] = None, # Placeholder for now
-        ip_address: Optional[str] = None,
-        user_agent: Optional[str] = None,
-        session_id: Optional[str] = None,
+        user_id: Optional[str] = "system", # Default to 'system' for automated processes
+        patient_id_to_hash: Optional[str] = None, # Raw Patient ID to be hashed
         failure_reason: Optional[str] = None,
-        details: Optional[Dict[str, Any]] = None
-    ):
+        details: Optional[Dict[str, Any]] = None,
+        client_ip: Optional[str] = None,
+        user_agent: Optional[str] = None,
+        session_id: Optional[str] = None # For user sessions via API
+    ) -> bool:
         """
-        Creates and saves an audit log entry.
-        """
-        logger.debug(
-            "Attempting to log audit event",
-            action=action, user_id=user_id, resource=resource,
-            resource_id=resource_id, success=success
-        )
+        Logs an audit event to the database.
 
-        audit_log_entry = AuditLogModel(
-            # timestamp is server_default=func.now()
-            user_id=user_id,
-            action=action,
-            resource=resource,
-            resource_id=resource_id,
-            patient_id_hash=patient_id_hash, # Actual hashing TBD
-            ip_address=ip_address,
-            user_agent=user_agent,
-            session_id=session_id,
-            success=success,
-            failure_reason=failure_reason if not success else None, # Only store reason if failed
-            details=details
-        )
+        Args:
+            action: Verb describing the action (e.g., 'PROCESS_BATCH_START', 'CREATE_CLAIM').
+            success: Boolean indicating if the action was successful.
+            resource: The type of resource affected (e.g., 'ClaimBatch', 'Claim').
+            resource_id: The ID of the specific resource instance.
+            user_id: Identifier for the user or system performing the action.
+            patient_id_to_hash: Raw Patient ID. Hashing will be placeholder for now.
+            failure_reason: Reason for failure if success is False.
+            details: Additional structured information about the event (JSONB).
+            client_ip: IP address of the client (for API calls).
+            user_agent: User-Agent string of the client (for API calls).
+            session_id: Session identifier (for API calls).
+
+        Returns:
+            True if the log was successfully saved, False otherwise.
+        """
+
+        # Placeholder for hashing patient_id. In a real system, use a consistent, secure hash.
+        # For now, just appending '_hashed' or storing as is if no real hashing mechanism.
+        # REQUIREMENTS.md: self._hash_patient_id(patient_id)
+        # Let's just use a simple prefix for now.
+        hashed_patient_id = f"hashed_{patient_id_to_hash}" if patient_id_to_hash else None
+        if patient_id_to_hash and len(patient_id_to_hash) > 200 : # Avoid overly long pseudo-hash
+             hashed_patient_id = f"hashed_{patient_id_to_hash[:200]}"
+
+
+        log_entry_data = {
+            # 'timestamp' has server_default=func.now() in AuditLogModel
+            "user_id": user_id,
+            "action": action,
+            "resource": resource,
+            "resource_id": resource_id,
+            "patient_id_hash": hashed_patient_id,
+            "ip_address": client_ip,
+            "user_agent": user_agent,
+            "session_id": session_id,
+            "success": success,
+            "failure_reason": failure_reason if not success else None, # Only store reason if failed
+            "details": details
+        }
 
         try:
-            self.db.add(audit_log_entry)
-            await self.db.commit()
-            await self.db.refresh(audit_log_entry) # To get id, timestamp etc.
-            logger.info(
-                "Audit event logged successfully",
-                audit_log_id=audit_log_entry.id, action=action, user_id=user_id, success=success
-            )
+            # The db_session_factory is expected to be an async context manager provider
+            # like the one used in ParallelClaimsProcessor.
+            async with self.db_session_factory() as session: # type: AsyncSession
+                async with session.begin(): # Start a transaction for the log entry
+                    audit_log = AuditLogModel(**log_entry_data)
+                    session.add(audit_log)
+                    # The commit will happen when session.begin() exits if no error,
+                    # or rollback if an error occurs.
+                # If session.begin() is not used, then await session.commit() would be needed here.
+                # Using session.begin() is cleaner for single operations.
+
+            logger.debug("Audit event logged successfully.", action=action, resource=resource, resource_id=resource_id, user_id=user_id)
+            return True
         except Exception as e:
-            # If audit logging fails, we should not let it break the main operation.
-            # Log the error to standard application logs.
-            # In a more robust system, might push to a fallback logging mechanism (e.g., file, different queue).
             logger.error(
-                "Failed to save audit log to database",
-                action=action, user_id=user_id, resource=resource, resource_id=resource_id,
-                original_error=str(e),
-                exc_info=True # Include stack trace for the audit logging failure
+                "Failed to log audit event to database.",
+                action=action,
+                resource=resource,
+                resource_id=resource_id,
+                error=str(e),
+                exc_info=True
             )
-            # Do not rollback self.db here, as the main operation might have already committed
-            # or needs to commit. Audit logging should be as decoupled as possible from main transaction flow
-            # unless it's critical for the transaction itself (which is rare for general audit).
-            # This means if the session passed to AuditLoggerService is the same one used by the main
-            # operation, and the main operation fails and rolls back, this audit log add will also be rolled back.
-            # If audit must survive main op rollback, it needs its own session/transaction.
-            # For now, assume it shares session and lives/dies with main op's transaction.
-            #
-            # It might be safer to attempt a rollback of just the audit entry if the session is shared
-            # and the commit for audit is separate, but SQLAlchemy sessions don't quite work that way
-            # without nested transactions or more complex session management.
-            # If self.db.commit() here is THE commit for the whole operation, then this try/except
-            # is mainly for logging the audit failure itself if the commit fails due to the audit entry.
-            # If audit is "best effort" and main op commit is separate, this is fine.
-            # Given the current structure, this commit is specific to the audit log.
-            # If this commit fails, it will roll back only the audit log entry.
-            # If the session `self.db` is shared and committed by an outer scope, then this commit
-            # might be redundant or even cause issues if called mid-transaction.
-            # For now, assuming this service gets a session and is responsible for its own commit for audit.
-            # To make it truly independent, it would need its own AsyncSessionLocal().
-            # This will be reviewed when integrating.
-            # For this subtask, the provided structure is implemented.
-            # A simple solution is to not commit here, but let the calling function commit the session
-            # that this audit log entry was added to. Or make this service use its own session.
-            # Let's assume for now the service manages its own unit of work for the audit log.
-            # This implies the session passed might need careful handling or be a factory.
-            # The current structure is okay if the session is committed by the caller *after* this.
-            # However, the `await self.db.commit()` is here. This means it assumes it controls the commit for this entry.
-            # This is a common point of complexity for audit logging.
-            # For now, leaving as is per prompt.
+            return False
+
+    # Placeholder for actual hashing function if needed internally
+    # def _hash_patient_id(self, patient_id: str) -> str:
+    #     # Replace with actual secure hashing (e.g., HMAC-SHA256 with a secret key)
+    #     # For now, just a conceptual placeholder.
+    #     if not patient_id:
+    #         return None
+    #     return f"hashed_{hashlib.sha256(patient_id.encode()).hexdigest()}"

--- a/tests/unit/core/security/test_audit_logger_service.py
+++ b/tests/unit/core/security/test_audit_logger_service.py
@@ -1,128 +1,165 @@
 import pytest
-from unittest.mock import AsyncMock, MagicMock, patch
-from sqlalchemy.ext.asyncio import AsyncSession # For type hinting the mock session
+from unittest.mock import AsyncMock, MagicMock # Removed unused patch
+from typing import Any, Callable, Tuple
+
+from sqlalchemy.ext.asyncio import AsyncSession # For type hinting
 
 from claims_processor.src.core.security.audit_logger_service import AuditLoggerService
 from claims_processor.src.core.database.models.audit_log_db import AuditLogModel
 
 @pytest.fixture
-def mock_db_session() -> MagicMock:
-    session = MagicMock(spec=AsyncSession)
-    session.add = MagicMock()
-    # Configure commit and refresh to be awaitable (async)
-    session.commit = AsyncMock()
-    session.refresh = AsyncMock()
-    return session
+def mock_db_session_factory() -> Tuple[MagicMock, AsyncMock]: # Returns factory_mock, session_mock
+    mock_session = AsyncMock(spec=AsyncSession)
+    # Mock the begin_nested or begin method if used by the service, or just add for general session behavior
+    # AuditLoggerService uses session.begin() as an async context manager
+    mock_session_begin_cm = AsyncMock() # This is the context manager returned by session.begin()
+    mock_session_begin_cm.__aenter__.return_value = mock_session # Simulate entering 'async with session.begin()'
+    mock_session_begin_cm.__aexit__.return_value = None # Simulate successful exit from 'async with session.begin()'
+    mock_session.begin = MagicMock(return_value=mock_session_begin_cm) # session.begin() returns the CM
+
+    mock_session.add = MagicMock()
+    # mock_session.commit = AsyncMock() # Not needed as session.begin() handles commit
+    # mock_session.rollback = AsyncMock() # Not needed as session.begin() handles rollback
+
+    # The AuditLoggerService expects a factory that, when called, returns an async context manager
+    # which in turn yields the session.
+    async_cm_factory_yields = AsyncMock() # This is the context manager returned by db_session_factory()
+    async_cm_factory_yields.__aenter__.return_value = mock_session # The session object
+    async_cm_factory_yields.__aexit__.return_value = None # Simulate successful exit from 'async with db_session_factory()'
+
+    mock_session_factory_instance = MagicMock(spec=Callable[[], Any]) # Mock the factory callable itself
+    mock_session_factory_instance.return_value = async_cm_factory_yields # Factory call returns the context manager
+
+    return mock_session_factory_instance, mock_session
+
 
 @pytest.fixture
-def audit_logger_service(mock_db_session: MagicMock) -> AuditLoggerService:
-    return AuditLoggerService(db_session=mock_db_session)
+def audit_logger_service(mock_db_session_factory: Tuple[MagicMock, AsyncMock]) -> AuditLoggerService:
+    factory_mock, _ = mock_db_session_factory
+    return AuditLoggerService(db_session_factory=factory_mock)
 
 @pytest.mark.asyncio
-async def test_log_event_success(
-    audit_logger_service: AuditLoggerService,
-    mock_db_session: MagicMock
-):
-    await audit_logger_service.log_event(
-        action="TEST_ACTION_SUCCESS",
+async def test_log_event_success(audit_logger_service: AuditLoggerService, mock_db_session_factory: Tuple[MagicMock, AsyncMock]):
+    factory_mock, mock_session = mock_db_session_factory
+
+    success_flag = await audit_logger_service.log_event( # Renamed 'success' to 'success_flag' to avoid keyword clash
+        action="TEST_ACTION",
         success=True,
-        user_id="test_user",
         resource="TestResource",
-        resource_id="123",
-        ip_address="127.0.0.1",
+        resource_id="res_123",
+        user_id="test_user",
+        patient_id_to_hash="patient_abc",
+        details={"key": "value"},
+        client_ip="127.0.0.1",
         user_agent="TestAgent/1.0",
-        details={"key": "value"}
+        session_id="sess_xyz"
     )
 
-    mock_db_session.add.assert_called_once()
-    added_object = mock_db_session.add.call_args[0][0]
+    assert success_flag is True
+    mock_session.add.assert_called_once()
+    added_log_entry = mock_session.add.call_args[0][0]
 
-    assert isinstance(added_object, AuditLogModel)
-    assert added_object.action == "TEST_ACTION_SUCCESS"
-    assert added_object.success is True
-    assert added_object.user_id == "test_user"
-    assert added_object.resource == "TestResource"
-    assert added_object.resource_id == "123"
-    assert added_object.ip_address == "127.0.0.1"
-    assert added_object.user_agent == "TestAgent/1.0"
-    assert added_object.details == {"key": "value"}
-    assert added_object.failure_reason is None
+    assert isinstance(added_log_entry, AuditLogModel)
+    assert added_log_entry.action == "TEST_ACTION"
+    assert added_log_entry.success is True
+    assert added_log_entry.resource == "TestResource"
+    assert added_log_entry.resource_id == "res_123"
+    assert added_log_entry.user_id == "test_user"
+    assert added_log_entry.patient_id_hash == "hashed_patient_abc" # Based on placeholder hashing
+    assert added_log_entry.details == {"key": "value"}
+    assert added_log_entry.ip_address == "127.0.0.1"
+    assert added_log_entry.user_agent == "TestAgent/1.0"
+    assert added_log_entry.session_id == "sess_xyz"
+    assert added_log_entry.failure_reason is None
 
-    mock_db_session.commit.assert_called_once()
-    mock_db_session.refresh.assert_called_once_with(added_object)
+    # Check that the db_session_factory was called to get the session context manager
+    factory_mock.assert_called_once()
+    # Check that the session context manager was entered
+    factory_mock.return_value.__aenter__.assert_called_once()
+    # Check that session.begin() context manager was entered
+    mock_session.begin.assert_called_once()
+    mock_session.begin.return_value.__aenter__.assert_called_once()
+
 
 @pytest.mark.asyncio
-async def test_log_event_failure(
-    audit_logger_service: AuditLoggerService,
-    mock_db_session: MagicMock
-):
-    failure_msg = "Something went wrong"
+async def test_log_event_failure_db_error_on_add(audit_logger_service: AuditLoggerService, mock_db_session_factory: Tuple[MagicMock, AsyncMock]):
+    factory_mock, mock_session = mock_db_session_factory
+
+    mock_session.add.side_effect = Exception("Database add error")
+
+    success_flag = await audit_logger_service.log_event(action="DB_FAIL_ACTION", success=True)
+
+    assert success_flag is False
+    mock_session.add.assert_called_once()
+    # session.begin().__aexit__ should have been called with an exception type if 'add' fails within 'session.begin()' block
+    # This means the transaction would attempt to rollback.
+    mock_session.begin.return_value.__aexit__.assert_called_once()
+    assert mock_session.begin.return_value.__aexit__.call_args[0][0] is not None # exc_type should be set
+
+
+@pytest.mark.asyncio
+async def test_log_event_failure_db_error_on_commit(audit_logger_service: AuditLoggerService, mock_db_session_factory: Tuple[MagicMock, AsyncMock]):
+    factory_mock, mock_session = mock_db_session_factory
+
+    # Simulate error when session.begin() context manager exits (tries to commit)
+    mock_session.begin.return_value.__aexit__.side_effect = Exception("Database commit error")
+
+    success_flag = await audit_logger_service.log_event(action="DB_FAIL_COMMIT_ACTION", success=True)
+
+    assert success_flag is False
+    mock_session.add.assert_called_once() # Add was successful
+    mock_session.begin.return_value.__aexit__.assert_called_once() # __aexit__ was called and raised error
+    # When side_effect is an exception, the call_args might not be what we expect for normal exit.
+    # The important part is that __aexit__ was called and an exception occurred, leading to success_flag = False.
+
+
+@pytest.mark.asyncio
+async def test_log_event_failure_reason_populated(audit_logger_service: AuditLoggerService, mock_db_session_factory: Tuple[MagicMock, AsyncMock]):
+    factory_mock, mock_session = mock_db_session_factory
+
     await audit_logger_service.log_event(
-        action="TEST_ACTION_FAILURE",
+        action="FAILED_ACTION",
         success=False,
-        user_id="test_user_fail",
-        failure_reason=failure_msg,
-        details={"error_code": 500}
+        failure_reason="Something went wrong"
     )
 
-    mock_db_session.add.assert_called_once()
-    added_object = mock_db_session.add.call_args[0][0]
-
-    assert isinstance(added_object, AuditLogModel)
-    assert added_object.action == "TEST_ACTION_FAILURE"
-    assert added_object.success is False
-    assert added_object.user_id == "test_user_fail"
-    assert added_object.failure_reason == failure_msg
-    assert added_object.details == {"error_code": 500}
-
-    mock_db_session.commit.assert_called_once()
-    mock_db_session.refresh.assert_called_once_with(added_object)
+    mock_session.add.assert_called_once()
+    added_log_entry = mock_session.add.call_args[0][0]
+    assert added_log_entry.success is False
+    assert added_log_entry.failure_reason == "Something went wrong"
 
 @pytest.mark.asyncio
-@patch('claims_processor.src.core.security.audit_logger_service.logger') # Patch the logger
-async def test_log_event_db_commit_exception(
-    mock_logger: MagicMock, # Injected by @patch
-    audit_logger_service: AuditLoggerService,
-    mock_db_session: MagicMock
-):
-    mock_db_session.commit.side_effect = Exception("DB commit failed")
+async def test_log_event_default_user_id(audit_logger_service: AuditLoggerService, mock_db_session_factory: Tuple[MagicMock, AsyncMock]):
+    factory_mock, mock_session = mock_db_session_factory
+    await audit_logger_service.log_event(action="SYSTEM_ACTION", success=True)
 
-    await audit_logger_service.log_event(
-        action="TEST_DB_FAIL",
-        success=True
-    )
-
-    mock_db_session.add.assert_called_once()
-    mock_db_session.commit.assert_called_once()
-    mock_db_session.refresh.assert_not_called()
-
-    mock_logger.error.assert_called_once()
-    args, kwargs = mock_logger.error.call_args
-    assert "Failed to save audit log to database" in args[0]
-    assert kwargs.get('action') == "TEST_DB_FAIL"
-    assert "DB commit failed" in kwargs.get('original_error', '')
+    mock_session.add.assert_called_once()
+    added_log_entry = mock_session.add.call_args[0][0]
+    assert added_log_entry.user_id == "system"
 
 @pytest.mark.asyncio
-async def test_log_event_failure_reason_only_if_not_success(
-    audit_logger_service: AuditLoggerService,
-    mock_db_session: MagicMock
-):
-    await audit_logger_service.log_event(
-        action="TEST_SUCCESS_WITH_REASON",
-        success=True,
-        failure_reason="This should be ignored"
-    )
+async def test_log_event_patient_id_hashing_long_id(audit_logger_service: AuditLoggerService, mock_db_session_factory: Tuple[MagicMock, AsyncMock]):
+    factory_mock, mock_session = mock_db_session_factory
+    long_patient_id = "A" * 250
+    expected_hashed_id_prefix = "hashed_A"
 
-    added_object_success = mock_db_session.add.call_args[0][0]
-    assert added_object_success.failure_reason is None
+    await audit_logger_service.log_event(action="HASH_TEST_LONG", success=True, patient_id_to_hash=long_patient_id)
 
-    mock_db_session.add.reset_mock() # Reset for the next call assertion
+    mock_session.add.assert_called_once()
+    added_log_entry = mock_session.add.call_args[0][0]
+    assert added_log_entry.patient_id_hash.startswith(expected_hashed_id_prefix)
+    # The placeholder hash truncates at 200 for the original ID part before adding "hashed_"
+    # So, the hashed part should be "hashed_" + "A"*200
+    assert added_log_entry.patient_id_hash == f"hashed_{'A'*200}"
 
-    reason = "Actual failure"
-    await audit_logger_service.log_event(
-        action="TEST_FAILURE_WITH_REASON",
-        success=False,
-        failure_reason=reason
-    )
-    added_object_failure = mock_db_session.add.call_args[0][0]
-    assert added_object_failure.failure_reason == reason
+
+@pytest.mark.asyncio
+async def test_log_event_patient_id_hashing_none(audit_logger_service: AuditLoggerService, mock_db_session_factory: Tuple[MagicMock, AsyncMock]):
+    factory_mock, mock_session = mock_db_session_factory
+
+    await audit_logger_service.log_event(action="HASH_TEST_NONE", success=True, patient_id_to_hash=None)
+
+    mock_session.add.assert_called_once()
+    added_log_entry = mock_session.add.call_args[0][0]
+    assert added_log_entry.patient_id_hash is None
+```


### PR DESCRIPTION
This commit introduces an AuditLoggerService for recording key operational events to an audit_logs table, and integrates it into the ParallelClaimsProcessor.

Key changes:

1.  **Reviewed AuditLogModel:**
    *   Confirmed `AuditLogModel` aligns with your requirements for storing
      detailed audit information.

2.  **Implemented `AuditLoggerService`:**
    *   Created `claims_processor/src/core/security/audit_logger_service.py`.
    *   The service has an `__init__` method accepting a database session
      factory.
    *   The `async def log_event(...)` method:
        - Takes parameters for action, success status, resource details,
          user information, and other contextual data.
        - Constructs an `AuditLogModel` instance.
        - Saves the audit log entry to the database using an `AsyncSession`
          from the factory, with proper transaction management via
          `session.begin()`.
        - Includes placeholder logic for patient ID hashing.
        - Handles database errors during logging and returns True/False.

3.  **Integrated into `ParallelClaimsProcessor`:**
    *   `ParallelClaimsProcessor.__init__` now accepts an `AuditLoggerService`
      instance.
    *   In `process_claims_parallel`:
        - An audit event with `action="PROCESS_BATCH_START"` is logged at the
          beginning of batch processing.
        - An audit event with `action="PROCESS_BATCH_END"` is logged in a
          `finally` block to ensure execution. This log includes the success
          status of the batch operation itself and a summary of processing
          results in its `details` field.

4.  **Unit Tests Added/Updated:**
    *   Created `tests/unit/core/security/test_audit_logger_service.py` with
      comprehensive tests for `AuditLoggerService.log_event`, covering
      successful logging, data mapping, error handling, default values, and
      mocked database interactions.
    *   Updated unit tests for `ParallelClaimsProcessor` in
      `tests/unit/processing/pipeline/test_parallel_claims_processor.py` to:
        - Inject a mocked `AuditLoggerService`.
        - Verify that `audit_logger_service.log_event` is called for batch
          start and end events with appropriate arguments.

This provides a foundational audit trail for batch processing operations.